### PR TITLE
Deploy command for deploying code to a remote server

### DIFF
--- a/.chef/knife_example.rb
+++ b/.chef/knife_example.rb
@@ -1,0 +1,15 @@
+# See http://docs.opscode.com/config_rb_knife.html for more information on knife configuration options
+
+current_dir = File.dirname(__FILE__)
+log_level                :info
+log_location             STDOUT
+node_name                "insert_node_name_here" # so the chef server can identify your user
+client_key               "#{current_dir}/insert_client_key_name_here.pem" # the key associated with your user
+validation_client_name   "cyclesafe" # 
+validation_key           "#{current_dir}/cyclesafe.pem"
+chef_server_url          "https://api.opscode.com/organizations/cyclesafe"
+cache_type               'BasicFile'
+cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
+cookbook_path            [ ]
+
+knife[:secret_file] = "#{current_dir}/encrypted_data_bag_secret"

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,37 @@
+
+#
+# CycleSafe deployment script for handling deployments to servers
+#   Wraps knife ssh
+#
+
+from optparse import OptionParser
+import json, os
+
+# configure option parser
+parser = OptionParser()
+parser.add_option("-u","--ssh-user", dest="username",
+                  help="SSH user to perform deployment as")
+parser.add_option("-n", "--node-name", dest="nodename",
+                  help="Node name string match for deployment")
+parser.add_option("-g","--repository", dest="repository",
+                  help="Path to git repository to be used for deployment")
+parser.add_option("-r","--revision", dest="revision", default="deploy",
+                  help="Revision branch/tag for git repository (defaults to deploy)")
+parser.add_option("-e","--environment", dest="environment", default="production",
+                  help="Chef environment to be used to deploy")
+(options, args) = parser.parse_args()
+
+# setup json attributes
+json_attributes = {'cyclesafe_chef': {'revision': options.revision}}
+
+if options.repository != None:
+  json_attributes['cyclesafe_chef']['repository'] = options.repository
+
+# setup command strings
+server_cmd = "echo \"%s\" > config.json && chef-client -j config.json" %json.dumps(json_attributes).replace('"','\\"')
+knife_ssh_cmd = "knife ssh 'name:%s' '%s' -x %s --ssh-password" %(options.nodename,server_cmd,options.username)
+
+print knife_ssh_cmd
+run = raw_input("Is this the correct command? (y/n)> ")
+if run.lower() == "y":
+  os.system(knife_ssh_cmd)  

--- a/roles/application.rb
+++ b/roles/application.rb
@@ -1,0 +1,3 @@
+name "application"
+description "Delivers web content"
+run_list "recipe[cyclesafe_chef::application]", "recipe[cyclesafe_chef::sysadmins]"

--- a/roles/database.rb
+++ b/roles/database.rb
@@ -1,0 +1,3 @@
+name "database"
+description "Delivers web content"
+run_list "recipe[cyclesafe_chef::database]", "recipe[cyclesafe_chef::sysadmins]"


### PR DESCRIPTION
Instructions pending, this script wraps the knife ssh command and makes it easier to insert relevant repository and revision information to deploy to a remote application server.

This script is NOT scalable and is only truly useful for having ONE server to deploy code to. However, it massively simplifies our current deployment procedure and makes it so anyone can deploy, following the same steps.

Here are basic requirements:

REQUIRES:
- manage.chef.io account
- knife.rb configuration pointing to keys and encrypted_data_bag_secret

This will be updated in a wiki post at some point explaining how to use this script.
